### PR TITLE
Fix API key attribute mismatches in NewsCollector

### DIFF
--- a/src/data_collection/news_collector.py
+++ b/src/data_collection/news_collector.py
@@ -232,7 +232,7 @@ class NewsCollector:
     
     def get_the_news_api_news(self, query: str = "NASDAQ", hours_back: int = 24, company: str = None) -> List[Dict]:
         """Get news from The News API with enhanced content and company support"""
-        if not self.the_news_api_key or self.the_news_api_key == "DUMMY":
+        if not self.the_news_api_api_key or self.the_news_api_api_key == "DUMMY":
             logger.info("No The News API key provided, skipping The News API news")
             return []
             
@@ -985,7 +985,7 @@ class NewsCollector:
         try:
             url = "https://api.thenewsapi.com/v1/news/all"
             params = {
-                "api_token": self.the_news_api_key,
+                "api_token": self.the_news_api_api_key,
                 "search": query,
                 "language": "en",
                 "categories": "business",
@@ -1007,7 +1007,7 @@ class NewsCollector:
         try:
             url = "https://api.thenewsapi.com/v1/news/all"
             params = {
-                "api_token": self.the_news_api_key,
+                "api_token": self.the_news_api_api_key,
                 "search": company,
                 "language": "en",
                 "categories": "business",
@@ -1029,7 +1029,7 @@ class NewsCollector:
         try:
             url = "https://api.thenewsapi.com/v1/news/top"
             params = {
-                "api_token": self.the_news_api_key,
+                "api_token": self.the_news_api_api_key,
                 "language": "en",
                 "categories": "business",
                 "limit": str(limit)
@@ -1088,4 +1088,4 @@ class NewsCollector:
 
 
 # Global instance
-news_collector = NewsCollector() 
+news_collector = NewsCollector()    


### PR DESCRIPTION

# Fix API key attribute mismatches in NewsCollector

## Summary

This PR resolves attribute name mismatches in the `NewsCollector` class that were causing runtime errors during production validation. The issue was that the constructor initializes `self.the_news_api_api_key` but methods throughout the class were trying to access `self.the_news_api_key` (missing the `_api` suffix).

**Key Changes:**
- Updated all instances of `self.the_news_api_key` to `self.the_news_api_api_key` in `src/data_collection/news_collector.py`
- This resolves the "Cannot access attribute 'the_news_api_key'" errors that appeared during production validation
- Completes the API key attribute standardization started in PR #8

## Review & Testing Checklist for Human

This is a **YELLOW** risk change - relatively simple fix but needs verification:

- [ ] **Verify all attribute mismatches resolved**: Search the entire codebase for any remaining instances of `the_news_api_key` vs `the_news_api_api_key`
- [ ] **Test with real API keys**: Replace dummy API keys with actual NewsAPI credentials and verify news collection works end-to-end
- [ ] **Run production validation**: Execute `python production_validation_test.py` with real API keys to ensure no more attribute errors occur

**Recommended test plan:**
1. Configure real API keys in `.env` file
2. Run the production validation test suite
3. Check logs for any remaining attribute errors
4. Verify news articles are successfully collected from NewsAPI

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    Settings["src/config/settings.py<br/>Settings class"]:::context
    NewsCollector["src/data_collection/news_collector.py<br/>NewsCollector class"]:::major-edit
    ValidationTest["production_validation_test.py<br/>Validation framework"]:::context
    
    Settings -->|"defines: the_news_api_api_key"| NewsCollector
    NewsCollector -->|"methods now use correct<br/>attribute name"| ValidationTest
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#ADD8E6
    classDef context fill:#FFFFFF
```

### Notes

- This fix complements the previous fix in `production_validation_test.py` (PR #8) to complete the API key attribute standardization
- The circular import issue with `news_collector` module still persists but doesn't block this specific fix
- With dummy API keys, the system gracefully handles authentication failures and continues processing
- **Link to Devin run**: https://app.devin.ai/sessions/b36ac289c76c41fdb50cb74dbdd6bd5c
- **Requested by**: Christopher Saunders (@csaunders4z)
