### PR TITLE
Fix timezone handling in news collection system

### DIFF
--- a/planning/plan.md
+++ b/planning/plan.md
@@ -10,7 +10,7 @@
 
 ### News & Catalyst Enhancement
 - [x] **Integrate Finnhub news/sentiment in NewsCollector (phase 2)** - ✅ **COMPLETED**
-- [ ] Tune "today" logic for news (time zones, late-night/overnight articles)
+- [x] **Tune "today" logic for news (time zones, late-night/overnight articles)** - ✅ **COMPLETED (PR #17)**
 - [ ] Enhance catalyst detection (earnings, upgrades, M&A, etc.)
 - [ ] Add more news sources or robust fallback for low-news days
 
@@ -38,6 +38,15 @@
 ---
 
 ## Completed Tasks
+
+### News Timezone Handling ✅ **COMPLETED (PR #17)** - July 18, 2025
+- [x] Fixed timezone handling in news collection system to use US/Eastern consistently
+- [x] Updated API calls to use market timezone for date parameters instead of server time
+- [x] Fixed `_is_today_article()` methods across all news collectors to use market timezone
+- [x] Enhanced date parsing to handle timezone-naive dates by assuming UTC then converting to market timezone
+- [x] Ensured consistent "today" logic regardless of server timezone location
+- [x] Applied timezone fixes to: NewsCollector, StockNewsScraper, FreeNewsCollector, FinnhubNewsAdapter
+- [x] Addresses late-night/overnight article collection issues mentioned in plan
 
 ### Finnhub Integration Phase 2 ✅ **COMPLETED & MERGED (PR #14)** - July 16, 2025
 - [x] Implemented comprehensive news collection with sentiment analysis from Finnhub

--- a/src/data_collection/finnhub_news_adapter.py
+++ b/src/data_collection/finnhub_news_adapter.py
@@ -4,9 +4,10 @@ Provides company-specific news and sentiment with global circuit breaker/session
 """
 import os
 from datetime import datetime, timedelta
-from typing import List, Dict
+from typing import List, Dict, Optional
 from loguru import logger
 import requests
+import pytz
 
 from src.config.settings import get_settings
 
@@ -15,6 +16,7 @@ class FinnhubNewsAdapter:
     def __init__(self):
         self.settings = get_settings()
         self.api_key = self.settings.finnhub_api_key or os.getenv("FINNHUB_API_KEY", "")
+        self.market_tz = pytz.timezone('US/Eastern')
         self._finnhub_news_consecutive_failures = 0
         self._finnhub_news_failure_threshold = 5
         self._finnhub_news_disabled_for_session = False
@@ -29,16 +31,18 @@ class FinnhubNewsAdapter:
             return True
         return False
 
-    def get_company_news(self, symbol: str, from_date: str = None, to_date: str = None, limit: int = 8) -> List[Dict]:
+    def get_company_news(self, symbol: str, from_date: Optional[str] = None, to_date: Optional[str] = None, limit: int = 8) -> List[Dict]:
         """Get company-specific news from Finnhub."""
         if self._check_disabled():
             return []
         try:
             url = f"{self.base_url}/company-news"
             if not from_date:
-                from_date = (datetime.now() - timedelta(days=2)).strftime('%Y-%m-%d')
+                market_now = datetime.now(self.market_tz)
+                from_date = (market_now - timedelta(days=2)).strftime('%Y-%m-%d')
             if not to_date:
-                to_date = datetime.now().strftime('%Y-%m-%d')
+                market_now = datetime.now(self.market_tz)
+                to_date = market_now.strftime('%Y-%m-%d')
             params = {"symbol": symbol, "from": from_date, "to": to_date, "token": self.api_key}
             response = requests.get(url, params=params, timeout=10)
             response.raise_for_status()
@@ -51,19 +55,26 @@ class FinnhubNewsAdapter:
                     logger.error(f"Finnhub News API disabled for the remainder of this session after {self._finnhub_news_failure_threshold} consecutive failures.")
                 return []
             self._finnhub_news_consecutive_failures = 0
-            # Sort by datetime, filter today's articles
-            today = datetime.now().date()
-            today_articles = [
-                {
-                    "title": article.get("headline"),
-                    "description": article.get("summary"),
-                    "url": article.get("url"),
-                    "source": article.get("source"),
-                    "published_at": article.get("datetime"),
-                    "relevance_score": 8.0  # Placeholder, can improve
-                }
-                for article in data if datetime.fromtimestamp(article.get("datetime", 0)).date() == today
-            ]
+            # Sort by datetime, filter today's articles in market timezone
+            market_now = datetime.now(self.market_tz)
+            today_market = market_now.date()
+            today_articles = []
+            
+            for article in data:
+                timestamp = article.get("datetime", 0)
+                if timestamp:
+                    article_date = datetime.fromtimestamp(timestamp, tz=pytz.UTC)
+                    article_date_market = article_date.astimezone(self.market_tz)
+                    
+                    if article_date_market.date() == today_market:
+                        today_articles.append({
+                            "title": article.get("headline"),
+                            "description": article.get("summary"),
+                            "url": article.get("url"),
+                            "source": article.get("source"),
+                            "published_at": article.get("datetime"),
+                            "relevance_score": 8.0
+                        })
             return today_articles[:limit]
         except Exception as e:
             self._finnhub_news_consecutive_failures += 1


### PR DESCRIPTION
# Fix timezone handling in news collection system

## Summary

This PR addresses timezone inconsistencies in the news collection system that were causing issues with "today" article filtering and API date ranges. Previously, the system used `datetime.now()` (server timezone) for both API calls and article filtering, which led to inconsistent behavior when the server was in a different timezone than US/Eastern market hours.

**Key Changes:**
- Added `market_tz = pytz.timezone('US/Eastern')` to all news collector classes
- Updated `_is_today_article()` methods to use market timezone for date comparisons
- Fixed API calls to use market timezone for date parameters
- Enhanced date parsing to handle timezone-naive dates by assuming UTC then converting to market timezone
- Updated timestamp generation to use market timezone consistently

**Files Modified:**
- `news_collector.py` - Updated API calls and article filtering
- `stock_news_scraper.py` - Fixed `_is_today_article()` method
- `free_news_sources.py` - Fixed article filtering and timestamp generation
- `finnhub_news_adapter.py` - Updated API calls and filtering logic

This ensures that "today" means the same thing across all news collectors regardless of where the server is located, and fixes issues with late-night/overnight articles being incorrectly filtered.

## Review & Testing Checklist for Human

- [ ] **Test timezone consistency**: Run the app from different server timezones (simulate by changing system timezone) and verify "today" filtering works consistently
- [ ] **Test edge cases**: Verify article filtering works correctly for articles published around midnight in different timezones
- [ ] **Run existing tests**: Execute `python test_today_news_filtering.py` to ensure no regressions in news filtering
- [ ] **Test API calls**: Verify that news API calls use the correct date ranges (check logs for API parameters)
- [ ] **Check for runtime errors**: Import and instantiate each news collector class to ensure no import/initialization errors

**Recommended test plan**: Run the application in test mode (`python main.py --test`) and check that news collection works without errors, then try running with real API keys to verify API date parameters are correct.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    NewsCollector["news_collector.py<br/>NewsCollector class"]:::major-edit
    StockScraper["stock_news_scraper.py<br/>StockNewsScraper class"]:::major-edit
    FreeNews["free_news_sources.py<br/>FreeNewsCollector class"]:::major-edit
    Finnhub["finnhub_news_adapter.py<br/>FinnhubNewsAdapter class"]:::major-edit
    
    TestFile["test_today_news_filtering.py<br/>Existing test file"]:::context
    HostManager["host_manager.py<br/>Uses US/Eastern already"]:::context
    
    NewsCollector --> |"Uses market_tz for API calls"| ExternalAPI[External News APIs]:::context
    StockScraper --> |"Filters articles using market_tz"| NewsCollector
    FreeNews --> |"Filters articles using market_tz"| NewsCollector  
    Finnhub --> |"Uses market_tz for API calls"| ExternalAPI
    
    TestFile --> |"Tests all collectors"| NewsCollector
    TestFile --> StockScraper
    TestFile --> FreeNews
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

**Important:** This PR could not be fully tested due to API key validation issues during import. The timezone logic has been implemented consistently across all collectors following the existing pattern used in `host_manager.py` and `script_generator.py`, but runtime testing is essential.

**Edge case handling:** The updated `_is_today_article()` methods now handle various date formats and assume UTC timezone for timezone-naive dates before converting to market timezone. This should be more robust than the previous server-timezone approach.

**Session info:** Implemented by Devin AI for Christopher Saunders (@csaunders4z)  
**Link to Devin run:** https://app.devin.ai/sessions/7fb5fd0552b6498fb180621ea75a3b75