### PR TITLE
Fix Biztoc API missing methods and improve rate limiting

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -2,10 +2,10 @@
 
 ## 🚨 Immediate Action Items (From Production Validation)
 
-### 1. Fix API Authentication Issues
-- [ ] **NewsAPI 401 Errors**: Code incorrectly uses `the_news_api_api_key` for newsapi.org requests, should use `NEWSAPI_API_KEY`
-- [ ] Add missing `newsapi_api_key` field to Settings class
-- [ ] Update news_collector.py to use correct API key for each service
+### 1. Fix API Authentication Issues ✅ COMPLETED
+- [x] **NewsAPI 401 Errors**: Code incorrectly uses `the_news_api_api_key` for newsapi.org requests, should use `NEWSAPI_API_KEY`
+- [x] Add missing `newsapi_api_key` field to Settings class
+- [x] Update news_collector.py to use correct API key for each service
 
 ### 2. Address Rate Limiting Problems  
 - [ ] **Finnhub API**: Implement exponential backoff, currently hits rate limits after 5 requests
@@ -14,7 +14,7 @@
 
 ### 3. Resolve System Architecture Issues
 - [ ] **Circular Import**: Fix "cannot import name 'news_collector'" initialization issue
-- [ ] **Missing Dependency**: Add `feedparser` to requirements.txt
+- [x] **Missing Dependency**: Add `feedparser` to requirements.txt ✅ COMPLETED
 - [ ] Update module imports to prevent circular dependencies
 
 ### 4. Improve Data Collection Coverage
@@ -55,8 +55,9 @@
 - **Cost Tracking**: Functional ($7.85/month estimate)
 
 ## 📋 Next Steps
-1. **PRIORITY 1**: Fix NewsAPI authentication (in progress)
-2. **PRIORITY 2**: Add missing dependencies to requirements.txt
-3. **PRIORITY 3**: Implement rate limiting improvements
-4. **PRIORITY 4**: Address circular import issues
-5. **PRIORITY 5**: Improve data collection coverage
+1. **PRIORITY 1**: Fix NewsAPI authentication ✅ COMPLETED
+2. **PRIORITY 2**: Add missing dependencies to requirements.txt ✅ COMPLETED
+3. **PRIORITY 3**: Fix Biztoc API missing methods (AttributeError for _get_biztoc_trending, _get_biztoc_company_news) ✅ COMPLETED
+4. **PRIORITY 4**: Implement rate limiting improvements
+5. **PRIORITY 5**: Address circular import issues
+6. **PRIORITY 6**: Improve data collection coverage

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -93,6 +93,10 @@ class Settings(BaseSettings):
     rate_limit_backoff_multiplier: float = Field(default=2.0, env="RATE_LIMIT_BACKOFF_MULTIPLIER")
     max_rate_limit_delay: float = Field(default=30.0, env="MAX_RATE_LIMIT_DELAY")  # Max delay in seconds
     
+    # Biztoc API Rate Limiting
+    biztoc_rate_limit_delay: float = Field(default=1.0, env="BIZTOC_RATE_LIMIT_DELAY")  # Seconds between Biztoc calls
+    biztoc_batch_delay: float = Field(default=2.0, env="BIZTOC_BATCH_DELAY")  # Delay between batches
+    
     # Collection Limits
     max_symbols_per_collection: int = Field(default=200, env="MAX_SYMBOLS_PER_COLLECTION")  # Max symbols to collect (increased for expanded coverage)
     collection_timeout_minutes: int = Field(default=15, env="COLLECTION_TIMEOUT_MINUTES")  # Max collection time (increased for larger datasets)
@@ -129,4 +133,4 @@ def get_finnhub_api_key():
     return os.getenv("FINNHUB_API_KEY", "")
 
 def get_alpha_vantage_api_key():
-    return os.getenv("ALPHA_VANTAGE_API_KEY", "")        
+    return os.getenv("ALPHA_VANTAGE_API_KEY", "")                


### PR DESCRIPTION
# Fix Biztoc API missing methods and improve rate limiting

## Summary

This PR resolves critical production errors where the NewsCollector was trying to call missing `_get_biztoc_trending` and `_get_biztoc_company_news` methods, causing AttributeError exceptions that prevented the daily workflow from completing.

**Key Changes:**
- ✅ **Added missing Biztoc API methods** following existing patterns with circuit breaker logic
- ✅ **Fixed type annotations** for Optional parameters across multiple methods  
- ✅ **Added Biztoc rate limiting configuration** to Settings class
- ✅ **Fixed missing return statement** in `_get_biztoc_search` method
- ✅ **Updated plan.md** to track completion

**Verification:** Production workflow test confirmed the AttributeError is resolved and circuit breaker logic works properly, disabling Biztoc after rate limit failures.

## Review & Testing Checklist for Human

- [ ] **Verify API endpoints exist**: Test that `/trending` and `/company` endpoints actually exist on Biztoc API (inferred from patterns, not documented)
- [ ] **Run complete production workflow**: Execute `python main.py` to ensure no regressions and full end-to-end functionality  
- [ ] **Test circuit breaker behavior**: Verify that failures in one Biztoc method properly affect the session-level disable flag
- [ ] **Check rate limiting integration**: Confirm new Biztoc rate limiting settings are used by the actual rate limiter logic

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    main["main.py"]:::context
    settings["src/config/settings.py"]:::minor-edit
    collector["src/data_collection/news_collector.py"]:::major-edit
    plan["plan.md"]:::minor-edit
    
    main --> collector
    collector --> settings
    
    subgraph collector_methods["NewsCollector Methods"]
        search["_get_biztoc_search"]:::context
        market["_get_biztoc_market_news"]:::context
        trending["_get_biztoc_trending"]:::major-edit
        company["_get_biztoc_company_news"]:::major-edit
        main_method["get_biztoc_news"]:::minor-edit
    end
    
    collector --> collector_methods
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **API Documentation Issue**: RapidAPI documentation for Biztoc returned 404 errors, so endpoint structure was inferred from existing `/search` and `/market` patterns
- **Circuit Breaker Logic**: All Biztoc methods share the same failure counter and session-level disable flag, following existing pattern
- **Rate Limiting**: Added configuration fields but integration with actual RateLimiter class may need verification
- **Testing Status**: AttributeError fix confirmed, but full production workflow was interrupted during OpenAI script generation phase

**Session Details:**
- Requested by: Christopher Saunders (@csaunders4z)  
- Link to Devin run: https://app.devin.ai/sessions/2532c0a1aa0d40069740ef54cf5e7b5d